### PR TITLE
Add missing pac pages commands: download-code-site, upload-code-site, migrate-datamodel

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,21 @@
 				"command": "portal-helper-vscode.CreateDeploymentProfile",
 				"category": "Portal Helper",
 				"title": "Create Deployment Profile"
+			},
+			{
+				"command": "portal-helper-vscode.downloadCodeSite",
+				"category": "Portal Helper",
+				"title": "Download Code Site"
+			},
+			{
+				"command": "portal-helper-vscode.uploadCodeSite",
+				"category": "Portal Helper",
+				"title": "Upload Code Site"
+			},
+			{
+				"command": "portal-helper-vscode.migrateDatamodel",
+				"category": "Portal Helper",
+				"title": "Migrate Data Model"
 			}
 		],
 		"menus": {

--- a/src/Actions/PortalActions.ts
+++ b/src/Actions/PortalActions.ts
@@ -327,6 +327,158 @@ export class PortalActions {
     Terminal.RunCommand(Commands.BootstrapMigrate(localPortalPath));
   }
 
+  public async DownloadCodeSite() {
+    vscode.window.showInformationMessage("Portal Helper: Download Code Site");
+
+    const localPathOptions: vscode.InputBoxOptions = {
+      prompt: "Enter local path where the code site will be downloaded or c for current folder",
+      placeHolder: "Local path C:\\Code\\Sites",
+    };
+
+    let localPath = await vscode.window.showInputBox(localPathOptions);
+
+    if (!localPath) {
+      vscode.window.showErrorMessage(
+        "Portal Helper: You need to provide a local path for the code site to be downloaded into"
+      );
+      return;
+    }
+
+    if (localPath === "c" && vscode.workspace.workspaceFolders) {
+      localPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    }
+
+    const websiteIdOptions: vscode.InputBoxOptions = {
+      prompt: "Provide Id of the code site to download",
+      placeHolder: "Id like 00000000-0000-0000-0000-000000000000",
+    };
+
+    const websiteId = await vscode.window.showInputBox(websiteIdOptions);
+
+    if (!websiteId) {
+      vscode.window.showErrorMessage(
+        "Portal Helper: You need to provide the website ID"
+      );
+      return;
+    }
+
+    const overwriteItems: string[] = ["Yes", "No"];
+    const overwriteOptions: vscode.QuickPickOptions = {
+      canPickMany: false,
+      placeHolder: "Overwrite existing content? (optional)",
+    };
+
+    const overwritePick = await vscode.window.showQuickPick(overwriteItems, overwriteOptions);
+    const overwrite = overwritePick === "Yes";
+
+    Terminal.RunCommand(Commands.DownloadCodeSite(localPath, websiteId, overwrite));
+  }
+
+  public async UploadCodeSite() {
+    vscode.window.showInformationMessage("Portal Helper: Upload Code Site");
+
+    const rootPathOptions: vscode.InputBoxOptions = {
+      prompt: "Enter root source folder path or c for current folder",
+      placeHolder: "Local path C:\\Code\\my-site",
+    };
+
+    let rootPath = await vscode.window.showInputBox(rootPathOptions);
+
+    if (!rootPath) {
+      vscode.window.showErrorMessage(
+        "Portal Helper: You need to provide the root path for the code site"
+      );
+      return;
+    }
+
+    if (rootPath === "c" && vscode.workspace.workspaceFolders) {
+      rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    }
+
+    const compiledPathOptions: vscode.InputBoxOptions = {
+      prompt: "Enter path to compiled/build output (optional, press Enter to skip)",
+      placeHolder: "C:\\Code\\my-site\\build",
+    };
+
+    const compiledPathInput = await vscode.window.showInputBox(compiledPathOptions);
+    const compiledPath = compiledPathInput || undefined;
+
+    const siteNameOptions: vscode.InputBoxOptions = {
+      prompt: "Enter display name for the site (optional, press Enter to skip)",
+      placeHolder: "My Power Pages Site",
+    };
+
+    const siteNameInput = await vscode.window.showInputBox(siteNameOptions);
+    const siteName = siteNameInput || undefined;
+
+    Terminal.RunCommand(Commands.UploadCodeSite(rootPath, compiledPath, siteName));
+  }
+
+  public async MigrateDatamodel() {
+    vscode.window.showInformationMessage("Portal Helper: Migrate Data Model");
+
+    const actionItems: string[] = ["Migrate", "Check Status", "Reset Migration", "Revert to Standard Data Model"];
+    const actionOptions: vscode.QuickPickOptions = {
+      canPickMany: false,
+      placeHolder: "Select action to perform",
+    };
+
+    const action = await vscode.window.showQuickPick(actionItems, actionOptions);
+
+    if (!action) {
+      return;
+    }
+
+    const websiteIdOptions: vscode.InputBoxOptions = {
+      prompt: "Provide the website ID",
+      placeHolder: "Id like 00000000-0000-0000-0000-000000000000",
+    };
+
+    const websiteId = await vscode.window.showInputBox(websiteIdOptions);
+
+    if (!websiteId) {
+      vscode.window.showErrorMessage(
+        "Portal Helper: You need to provide the website ID"
+      );
+      return;
+    }
+
+    if (action === "Check Status") {
+      Terminal.RunCommand(Commands.MigrateDatamodel(websiteId, true));
+      return;
+    }
+
+    if (action === "Reset Migration") {
+      Terminal.RunCommand(Commands.MigrateDatamodel(websiteId, false, undefined, false, true));
+      return;
+    }
+
+    if (action === "Revert to Standard Data Model") {
+      Terminal.RunCommand(Commands.MigrateDatamodel(websiteId, false, undefined, false, false, true));
+      return;
+    }
+
+    // Migrate action
+    const modeItems: string[] = ["all", "configurationData", "configurationDataReferences"];
+    const modeOptions: vscode.QuickPickOptions = {
+      canPickMany: false,
+      placeHolder: "Select migration mode",
+    };
+
+    const mode = await vscode.window.showQuickPick(modeItems, modeOptions);
+
+    const updateItems: string[] = ["Yes", "No"];
+    const updateOptions: vscode.QuickPickOptions = {
+      canPickMany: false,
+      placeHolder: "Update data model version after successful migration?",
+    };
+
+    const updatePick = await vscode.window.showQuickPick(updateItems, updateOptions);
+    const updateVersion = updatePick === "Yes";
+
+    Terminal.RunCommand(Commands.MigrateDatamodel(websiteId, false, mode, updateVersion));
+  }
+
   public async CreateCustomJS(selectedUri: vscode.Uri) {
     vscode.window.showInformationMessage("Portal Helper: Create Custom JS");
 

--- a/src/Actions/PortalActions.ts
+++ b/src/Actions/PortalActions.ts
@@ -467,6 +467,10 @@ export class PortalActions {
 
     const mode = await vscode.window.showQuickPick(modeItems, modeOptions);
 
+    if (!mode) {
+      return;
+    }
+
     const updateItems: string[] = ["Yes", "No"];
     const updateOptions: vscode.QuickPickOptions = {
       canPickMany: false,

--- a/src/Helpers/Commands.ts
+++ b/src/Helpers/Commands.ts
@@ -23,6 +23,28 @@ export class Commands {
         return `pac pages bootstrap-migrate -p "${localPath}"`;
     }
 
+    public static DownloadCodeSite(localPath: string, websiteId: string, overwrite?: boolean) {
+        const overwriteText = overwrite ? `-o` : '';
+        return `pac pages download-code-site -p "${localPath}" -id ${websiteId} ${overwriteText}`.trim();
+    }
+
+    public static UploadCodeSite(rootPath: string, compiledPath?: string, siteName?: string) {
+        const compiled = compiledPath ? `-cp "${compiledPath}"` : '';
+        const name = siteName ? `-sn "${siteName}"` : '';
+        return `pac pages upload-code-site -rp "${rootPath}" ${compiled} ${name}`.trim().replace(/\s+/g, ' ');
+    }
+
+    public static MigrateDatamodel(websiteId: string, checkStatus?: boolean, mode?: string,
+        updateVersion?: boolean, reset?: boolean, revert?: boolean) {
+        const check = checkStatus ? `-s` : '';
+        const modeText = mode ? `-m "${mode}"` : '';
+        const update = updateVersion ? `-u` : '';
+        const resetText = reset ? `-rs` : '';
+        const revertText = revert ? `-r` : '';
+        return `pac pages migrate-datamodel -id ${websiteId} ${check} ${modeText} ${update} ${resetText} ${revertText}`
+            .trim().replace(/\s+/g, ' ');
+    }
+
     public static AuthList() {
         return 'pac auth list';
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,24 @@ export function activate(context: vscode.ExtensionContext) {
 			portalActions.CreateDeploymentProfile();
 		})
 	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('portal-helper-vscode.downloadCodeSite', () => {
+			portalActions.DownloadCodeSite();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('portal-helper-vscode.uploadCodeSite', () => {
+			portalActions.UploadCodeSite();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('portal-helper-vscode.migrateDatamodel', () => {
+			portalActions.MigrateDatamodel();
+		})
+	);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
## Why

The PAC CLI introduced three `pac pages` commands that weren't yet covered by this extension:

- `pac pages download-code-site` — for downloading Power Pages SPA/code sites
- `pac pages upload-code-site` — for uploading compiled SPA code to a Power Pages environment
- `pac pages migrate-datamodel` — for managing the migration from the standard to the enhanced data model

Without these, users working with Power Pages code sites or performing data model migrations had to fall back to running commands manually in the terminal.

## What changed

Each new command follows the same layered pattern used throughout the extension (Commands → PortalActions → extension.ts → package.json):

**`pac pages download-code-site`** (`Portal Helper: Download Code Site`)
- Prompts for local path (supports `c` for current workspace folder), website ID, and an optional overwrite toggle.

**`pac pages upload-code-site`** (`Portal Helper: Upload Code Site`)
- Prompts for the root source path, an optional compiled/build output path (`--compiledPath`), and an optional site display name (`--siteName`).

**`pac pages migrate-datamodel`** (`Portal Helper: Migrate Data Model`)
- Opens a QuickPick with four sub-actions: **Migrate**, **Check Status**, **Reset Migration**, and **Revert to Standard Data Model**.
- The Migrate flow additionally prompts for migration mode (`all` / `configurationData` / `configurationDataReferences`) and whether to auto-update the data model version on success.

## Files changed

| File | Change |
|---|---|
| `src/Helpers/Commands.ts` | 3 new static command builder methods |
| `src/Actions/PortalActions.ts` | 3 new async action methods |
| `src/extension.ts` | 3 new `vscode.commands.registerCommand` entries |
| `package.json` | 3 new entries under `contributes.commands` |